### PR TITLE
[version] new version 19201

### DIFF
--- a/frida/config/addresses.11581.json
+++ b/frida/config/addresses.11581.json
@@ -2,5 +2,5 @@
     "Version": 11581,
     "LoadStartHookOffset": "0x28E9190",
     "CDPFilterHookOffset": "0x38C4350",
-    "SceneOffsets": [1208, 1160]
+    "SceneOffsets": [1208, 1160, 488]
 }

--- a/frida/config/addresses.11633.json
+++ b/frida/config/addresses.11633.json
@@ -2,5 +2,5 @@
     "Version": 11633,
     "LoadStartHookOffset": "0x28F22A0",
     "CDPFilterHookOffset": "0x38D41E0",
-    "SceneOffsets": [1208, 1160]
+    "SceneOffsets": [1208, 1160, 488]
 }

--- a/frida/config/addresses.13331.json
+++ b/frida/config/addresses.13331.json
@@ -2,5 +2,5 @@
     "Version": 13331,
     "LoadStartHookOffset": "0x0FFC200",
     "CDPFilterHookOffset": "0x2420100",
-    "SceneOffsets": [1272, 1224]
+    "SceneOffsets": [1272, 1224, 488]
 }

--- a/frida/config/addresses.13341.json
+++ b/frida/config/addresses.13341.json
@@ -2,5 +2,5 @@
     "Version": 13341,
     "LoadStartHookOffset": "0x10009E0",
     "CDPFilterHookOffset": "0x242E8E0",
-    "SceneOffsets": [1272, 1224]
+    "SceneOffsets": [1272, 1224, 488]
 }

--- a/frida/config/addresses.13487.json
+++ b/frida/config/addresses.13487.json
@@ -2,5 +2,5 @@
     "Version": 13487,
     "LoadStartHookOffset": "0x0FFB600",
     "CDPFilterHookOffset": "0x241FEB0",
-    "SceneOffsets": [1272, 1224]
+    "SceneOffsets": [1272, 1224, 488]
 }

--- a/frida/config/addresses.13639.json
+++ b/frida/config/addresses.13639.json
@@ -2,5 +2,5 @@
     "Version": 13639,
     "LoadStartHookOffset": "0x1000990",
     "CDPFilterHookOffset": "0x2424DE0",
-    "SceneOffsets": [1272, 1224]
+    "SceneOffsets": [1272, 1224, 488]
 }

--- a/frida/config/addresses.13655.json
+++ b/frida/config/addresses.13655.json
@@ -2,5 +2,5 @@
     "Version": 13655,
     "LoadStartHookOffset": "0x100F4B0",
     "CDPFilterHookOffset": "0x244A9E0",
-    "SceneOffsets": [1280, 1232]
+    "SceneOffsets": [1280, 1232, 488]
 }

--- a/frida/config/addresses.13871.json
+++ b/frida/config/addresses.13871.json
@@ -2,5 +2,5 @@
     "Version": 13871,
     "LoadStartHookOffset": "0x101F160",
     "CDPFilterHookOffset": "0x246FC40",
-    "SceneOffsets": [1360, 1312]
+    "SceneOffsets": [1360, 1312, 488]
 }

--- a/frida/config/addresses.13909.json
+++ b/frida/config/addresses.13909.json
@@ -2,5 +2,5 @@
     "Version": 13909,
     "LoadStartHookOffset": "0x101F0E0",
     "CDPFilterHookOffset": "0x246FDC0",
-    "SceneOffsets": [1360, 1312]
+    "SceneOffsets": [1360, 1312, 488]
 }

--- a/frida/config/addresses.14161.json
+++ b/frida/config/addresses.14161.json
@@ -2,5 +2,5 @@
     "Version": 14161,
     "LoadStartHookOffset": "0x10246C0",
     "CDPFilterHookOffset": "0x24839B0",
-    "SceneOffsets": [1360, 1312]
+    "SceneOffsets": [1360, 1312, 488]
 }

--- a/frida/config/addresses.14199.json
+++ b/frida/config/addresses.14199.json
@@ -2,5 +2,5 @@
     "Version": 14199,
     "LoadStartHookOffset": "0x10246F0",
     "CDPFilterHookOffset": "0x24839E0",
-    "SceneOffsets": [1360, 1312]
+    "SceneOffsets": [1360, 1312, 488]
 }

--- a/frida/config/addresses.14315.json
+++ b/frida/config/addresses.14315.json
@@ -2,5 +2,5 @@
     "Version": 14315,
     "LoadStartHookOffset": "0x10004C0",
     "CDPFilterHookOffset": "0x2424B50",
-    "SceneOffsets": [1272, 1224]
+    "SceneOffsets": [1272, 1224, 488]
 }

--- a/frida/config/addresses.16133.json
+++ b/frida/config/addresses.16133.json
@@ -2,5 +2,5 @@
     "Version": 16133,
     "LoadStartHookOffset": "0x470FAD0",
     "CDPFilterHookOffset": "0x90FC7E0",
-    "SceneOffsets": [1360, 1312]
+    "SceneOffsets": [1360, 1312, 488]
 }

--- a/frida/config/addresses.16203.json
+++ b/frida/config/addresses.16203.json
@@ -2,5 +2,5 @@
     "Version": 16203,
     "LoadStartHookOffset": "0x4710890",
     "CDPFilterHookOffset": "0x90FD640",
-    "SceneOffsets": [1360, 1312]
+    "SceneOffsets": [1360, 1312, 488]
 }

--- a/frida/config/addresses.16389.json
+++ b/frida/config/addresses.16389.json
@@ -2,5 +2,5 @@
     "Version": 16389,
     "LoadStartHookOffset": "0x24E4830",
     "CDPFilterHookOffset": "0x2E2A880",
-    "SceneOffsets": [1360, 1312]
+    "SceneOffsets": [1360, 1312, 488]
 }

--- a/frida/config/addresses.16467.json
+++ b/frida/config/addresses.16467.json
@@ -2,5 +2,5 @@
     "Version": 16467,
     "LoadStartHookOffset": "0x24E4FD0",
     "CDPFilterHookOffset": "0x2E2CC90",
-    "SceneOffsets": [1360, 1312]
+    "SceneOffsets": [1360, 1312, 488]
 }

--- a/frida/config/addresses.16771.json
+++ b/frida/config/addresses.16771.json
@@ -2,5 +2,5 @@
     "Version": 16771,
     "LoadStartHookOffset": "0x24E9130",
     "CDPFilterHookOffset": "0x2E3C470",
-    "SceneOffsets": [1360, 1312]
+    "SceneOffsets": [1360, 1312, 488]
 }

--- a/frida/config/addresses.16815.json
+++ b/frida/config/addresses.16815.json
@@ -2,5 +2,5 @@
     "Version": 16815,
     "LoadStartHookOffset": "0x2509690",
     "CDPFilterHookOffset": "0x2E768D0",
-    "SceneOffsets": [1416, 1360]
+    "SceneOffsets": [1416, 1360, 488]
 }

--- a/frida/config/addresses.16965.json
+++ b/frida/config/addresses.16965.json
@@ -2,5 +2,5 @@
     "Version": 16965,
     "LoadStartHookOffset": "0x2570220",
     "CDPFilterHookOffset": "0x2F844A0",
-    "SceneOffsets": [1416, 1360]
+    "SceneOffsets": [1416, 1360, 488]
 }

--- a/frida/config/addresses.17037.json
+++ b/frida/config/addresses.17037.json
@@ -2,5 +2,5 @@
     "Version": 17037,
     "LoadStartHookOffset": "0x257D0A0",
     "CDPFilterHookOffset": "0x2FB2310",
-    "SceneOffsets": [1408, 1352]
+    "SceneOffsets": [1408, 1352, 488]
 }

--- a/frida/config/addresses.17071.json
+++ b/frida/config/addresses.17071.json
@@ -2,5 +2,5 @@
     "Version": 17071,
     "LoadStartHookOffset": "0x258F370",
     "CDPFilterHookOffset": "0x2FD3080",
-    "SceneOffsets": [1408, 1352]
+    "SceneOffsets": [1408, 1352, 488]
 }

--- a/frida/config/addresses.17127.json
+++ b/frida/config/addresses.17127.json
@@ -2,5 +2,5 @@
     "Version": 17127,
     "LoadStartHookOffset": "0x2590910",
     "CDPFilterHookOffset": "0x2FD4040",
-    "SceneOffsets": [1408, 1352]
+    "SceneOffsets": [1408, 1352, 488]
 }

--- a/frida/config/addresses.18055.json
+++ b/frida/config/addresses.18055.json
@@ -2,5 +2,5 @@
     "Version": 18055,
     "LoadStartHookOffset": "0x25A1040",
     "CDPFilterHookOffset": "0x30031E0",
-    "SceneOffsets": [1416, 1352]
+    "SceneOffsets": [1416, 1352, 488]
 }

--- a/frida/config/addresses.18151.json
+++ b/frida/config/addresses.18151.json
@@ -2,5 +2,5 @@
     "Version": 18151,
     "LoadStartHookOffset": "0x25A2E20",
     "CDPFilterHookOffset": "0x3013D20",
-    "SceneOffsets": [1416, 1352]
+    "SceneOffsets": [1416, 1352, 488]
 }

--- a/frida/config/addresses.18787.json
+++ b/frida/config/addresses.18787.json
@@ -2,5 +2,5 @@
     "Version": 18787,
     "LoadStartHookOffset": "0x25B2870",
     "CDPFilterHookOffset": "0x3028AD0",
-    "SceneOffsets": [1408, 1344]
+    "SceneOffsets": [1408, 1344, 488]
 }

--- a/frida/config/addresses.18891.json
+++ b/frida/config/addresses.18891.json
@@ -2,5 +2,5 @@
     "Version": 18891,
     "LoadStartHookOffset": "0x25B50C0",
     "CDPFilterHookOffset": "0x30245E0",
-    "SceneOffsets": [1408, 1344]
+    "SceneOffsets": [1408, 1344, 488]
 }

--- a/frida/config/addresses.18955.json
+++ b/frida/config/addresses.18955.json
@@ -2,5 +2,5 @@
     "Version": 18955,
     "LoadStartHookOffset": "0x25B52C0",
     "CDPFilterHookOffset": "0x30248B0",
-    "SceneOffsets": [1408, 1344]
+    "SceneOffsets": [1408, 1344, 488]
 }

--- a/frida/config/addresses.19027.json
+++ b/frida/config/addresses.19027.json
@@ -2,5 +2,5 @@
     "Version": 19027,
     "LoadStartHookOffset": "0x25B52D0",
     "CDPFilterHookOffset": "0x3024AD0",
-    "SceneOffsets": [1408, 1344]
+    "SceneOffsets": [1408, 1344, 488]
 }

--- a/frida/config/addresses.19201.json
+++ b/frida/config/addresses.19201.json
@@ -1,0 +1,6 @@
+{
+    "Version": 19201,
+    "LoadStartHookOffset": "0x25B5DD0",
+    "CDPFilterHookOffset": "0x301B3C0",
+    "SceneOffsets": [1376, 1312, 456]
+}

--- a/frida/hook.js
+++ b/frida/hook.js
@@ -47,7 +47,7 @@ const hookOnLoadScene = (a1, sceneOffsets) => {
         .readPointer()
         .add(16)
         .readPointer()
-        .add(488);
+        .add(sceneOffsets[2]);
     send(`[hook] scene: ${miniappScenePtr.readInt()}`);
 
     // 1000: from issue #83 <-- will crash the process
@@ -108,7 +108,7 @@ const parseConfig = () => {
             Version: 18955,
             LoadStartHookOffset: "0x25B52C0",
             CDPFilterHookOffset: "0x30248B0",
-            SceneOffsets: [1408, 1344],
+            SceneOffsets: [1408, 1344, 488],
         };
     }
     return JSON.parse(rawConfig);


### PR DESCRIPTION
In newest version 19201, the current hardcoded `488` offset has changed to `456`, we add this offset to the `SceneOffsets` array.

<img width="1076" height="142" alt="image" src="https://github.com/user-attachments/assets/980972e8-9cb0-4f05-bb38-c27a57fa6276" />
