### PR TITLE
Add WMPF 20005 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This debugger (tweak) exploits Remote Debug feature provided by wechatdevtools a
 
 Version histories:
 
-* 19921 (latest)
+* 20005 (latest)
+* 19921
 * 19899 (credit @mathmonkeyliu)
 * 19881 (credit @WIAIV)
 * 19871

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,7 +9,8 @@
 
 支持的 WMPF 版本：
 
-* 19921 (最新)
+* 20005 (最新)
+* 19921
 * 19899 (credit @mathmonkeyliu)
 * 19881 (credit @WIAIV)
 * 19871

--- a/frida/config/addresses.20005.json
+++ b/frida/config/addresses.20005.json
@@ -1,0 +1,6 @@
+{
+    "Version": 20005,
+    "LoadStartHookOffset": "0x25DBBE0",
+    "CDPFilterHookOffset": "0x30C5D90",
+    "SceneOffsets": [64, 1480, 8, 1416, 16, 456]
+}


### PR DESCRIPTION
Add address config for WMPF 20005.

Validated locally:
- JSON config parses successfully
- `npx tsc --noEmit` passes

Offsets were derived from local 20005 `flue.dll` using the same anchors documented in `UPGRADE_19895_RUNBOOK.md`.