### PR TITLE
[version] new version 19977

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,18 @@ This debugger (tweak) exploits Remote Debug feature provided by wechatdevtools a
 
 Version histories:
 
-* 19921 (latest)
+* 19977 (latest)
+* 19921
 * 19899 (credit @mathmonkeyliu)
 * 19881 (credit @WIAIV)
 * 19871
 * 19841 (credit @AwangYes)
-* 19823 (credit @mathmonkeyliu)
 
 <details>
 
 <summary>Older versions</summary>
 
+* 19823 (credit @mathmonkeyliu)
 * 19769
 * 19749 (credit @xiaoriri, @Alfalfaaaa, @chengzongcai)
 * 19481 (credit @cosalone, @jiangjie)

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,17 +9,18 @@
 
 支持的 WMPF 版本：
 
-* 19921 (最新)
+* 19977 (最新)
+* 19921
 * 19899 (credit @mathmonkeyliu)
 * 19881 (credit @WIAIV)
 * 19871
 * 19841 (credit @AwangYes)
-* 19823 (credit @mathmonkeyliu)
 
 <details>
 
 <summary>更早版本</summary>
 
+* 19823 (credit @mathmonkeyliu)
 * 19769
 * 19749 (credit @xiaoriri, @Alfalfaaaa, @chengzongcai)
 * 19481 (credit @cosalone, @jiangjie)

--- a/frida/config/addresses.19977.json
+++ b/frida/config/addresses.19977.json
@@ -1,0 +1,6 @@
+{
+    "Version": 19977,
+    "LoadStartHookOffset": "0x25D14B0",
+    "CDPFilterHookOffset": "0x30B02B0",
+    "SceneOffsets": [64, 1480, 8, 1416, 16, 456]
+}


### PR DESCRIPTION
Adds offset config for **WMPF 19977** (bundled with the latest WeChat 4.x).

### Offsets

```json
{
    Version: 19977,
    LoadStartHookOffset: 0x25D14B0,
    CDPFilterHookOffset: 0x30B02B0,
    SceneOffsets: [64, 1480, 8, 1416, 16, 456]
}
```

### How they were found (per ADAPTATION.md)

- **LoadStartHookOffset `0x25D14B0`** — function that references both `applet_index_container.cc` and the `AppletIndexContainer::OnLoadStart` signature string.
- **CDPFilterHookOffset `0x30B02B0`** — first `call` inside the only xref function of `SendToClientFilter`.
- **SceneOffsets `[64, 1480, 8, 1416, 16, 456]`** — from the OnLoadStart tail `sub(*(*(a1+64)+1480), ...)` and the scene check `*(*(*( *(a1+8)+1416)+16)+456) != 1101` inside the callee. Compared to 19921 only off1 (1472→1480) and off3 (1408→1416) shifted by +8, consistent with a minor struct change.

### Verification

Tested at runtime on WeChat 4.x / WMPF 19977:

```
[frida] script loaded, WMPF version: 19977, pid: 26980
[inteceptor] AppletIndexContainer::OnLoadStart onEnter, indexContainer.this: 0x70ec033ebd00
[hook] scene: 1035
[hook] hook scene condition -> 1101
[miniapp] miniapp client connected
```

OnLoadStart hook fires, the scene pointer chain reads valid values, the scene is rewritten to 1101, and the miniapp connects to the debug server. No crashes across repeated loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)