### PR TITLE
Add WMPF 20079 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This debugger (tweak) exploits Remote Debug feature provided by wechatdevtools a
 
 Version histories:
 
-* 20005 (latest, credit @LiuYJia)
+* 20079 (latest, credit @LiuYJia)
+* 20005 (credit @LiuYJia)
 * 20001 (credit @B1397KB)
 * 19977 (credit @B1397KB, @yunm90872-ui, @chengzongcai)
 * 19921 

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,7 +9,8 @@
 
 支持的 WMPF 版本：
 
-* 20005 (最新, credit @LiuYJia)
+* 20079 (最新, credit @LiuYJia)
+* 20005 (credit @LiuYJia)
 * 20001 (credit @B1397KB)
 * 19977 (credit @B1397KB, @yunm90872-ui, @chengzongcai)
 * 19921 

--- a/frida/config/addresses.20079.json
+++ b/frida/config/addresses.20079.json
@@ -1,0 +1,6 @@
+{
+    "Version": 20079,
+    "LoadStartHookOffset": "0x25DFB90",
+    "CDPFilterHookOffset": "0x30CF310",
+    "SceneOffsets": [64, 1480, 8, 1416, 16, 456]
+}


### PR DESCRIPTION
## Summary
- Add Frida address config for WMPF 20079
- Mark 20079 as the latest supported WMPF version in both READMEs

## Validation
- Parsed frida/config/addresses.20079.json successfully
- npx tsc --noEmit
- Runtime checked locally with WMPF 20079 miniapp debugging