### PR TITLE
feat: add WeChat Official Account H5 page automatic debugging support

### DIFF
--- a/EXTENSION.md
+++ b/EXTENSION.md
@@ -1,6 +1,6 @@
 # WeChat Embedded Browser Page Debugging
 
-This is a simple workaround of utilizing existing debugging protocol to debug web pages of WeChat Embedded Browser.
+This is the manual fallback for debugging web pages of WeChat Embedded Browser. Prefer the automatic `--h5-url <keyword>` workflow in `README.md` first; use this document when automatic target matching cannot locate the desired page.
 
 ## Background
 
@@ -32,5 +32,3 @@ You can verify all targets via Protocol Monitor, and the miniapp tab (AppIndex) 
 All done. After these steps you have successfully attached to the tab. Please note that the Element tab will not update so you cannot use that panel to inspect the DOM tree. Also, you cannot close the miniapp since it will stop the debug session.
 
 In addition, for miniapps that using `webview` tag, you can also use the same method above to attach to the WebView tab and inspect.
-
-

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Version histories:
 
 </details>
 
-To debug web pages of WeChat embedded browser, please refer to [EXTENSION.md](EXTENSION.md). Note that this feature has many limitations currently and is simply a basic workaround.
+To debug web pages of WeChat embedded browser or WeChat Official Account H5 pages, start with `--h5-url <url-keyword>` to automatically attach to a matching embedded-browser target. If automatic target matching does not work, use the manual fallback in [EXTENSION.md](EXTENSION.md). Note that this feature depends on the CDP targets exposed by WeChat, so some panels such as Elements may still be limited.
 
 To check your installed version, navigate to Task Manager -> WeChatAppEx -> Right click -> Open file location -> Check the number between `RadiumWMPF` and `extracted`.
 
@@ -101,6 +101,18 @@ npx ts-node src/index.ts
 **Step 3.** Launch any miniapp you would like to debug.
 
 **Step 4.** Open your chromium-based browsers, navigate to `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:62000` and profit. You can change the CDP port `CDP_PORT` (62000 in this example) in `src/index.ts` to any port you like.
+
+### Debug WeChat Official Account H5 Pages
+
+Start the debugger with a URL keyword for the target H5 page:
+
+```bash
+npx ts-node src/index.ts --h5-url mp.weixin.qq.com
+```
+
+You still need to launch a miniapp first to initialize the debug session, then open the target H5 page in WeChat. After opening `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:62000`, the proxy searches for an embedded-browser target whose URL contains the keyword and attaches to that page automatically.
+
+If the logs say no matching target was found, make sure the H5 page is already open in WeChat or use a more specific URL keyword. When automatic attach fails, you can still use the Protocol Monitor fallback in [EXTENSION.md](EXTENSION.md).
 
 ## Screenshots
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -61,7 +61,7 @@
 
 </details>
 
-如何调试微信内置浏览器页面：参见 [EXTENSION.md](EXTENSION.md)。注意，目前该方法仅有基础调试功能
+如何调试微信内置浏览器/公众号 H5 页面：启动时传入 `--h5-url <URL关键字>` 可自动匹配并附加到对应页面；如果自动匹配不可用，参见 [EXTENSION.md](EXTENSION.md) 使用手动 fallback。注意，目前该方法依赖微信暴露的内置浏览器 CDP target，Elements 面板等能力可能仍有限。
 
 如何检查版本：打开任务管理器，找到 WeChatAppEx 进程，右键，打开文件所在的位置，检查在 `RadiumWMPF` 和 `extracted` 之间的数字
 
@@ -99,6 +99,18 @@ npx ts-node src/index.ts
 **第 3 步** 打开任意你想调试的小程序
 
 **第 4 步** 打开浏览器，访问 `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:62000` 即可。你也可以将 CDP 端口（在例子中为 62000）修改到任意其他端口。相关代码定义在 `src/index.ts` 中
+
+### 调试公众号 H5 页面
+
+启动调试器时传入 H5 页面的 URL 关键字，例如：
+
+```bash
+npx ts-node src/index.ts --h5-url mp.weixin.qq.com
+```
+
+随后仍需要先打开任意小程序来初始化调试会话，再在微信中打开目标公众号 H5 页面。打开浏览器访问 `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:62000` 后，代理会自动查找 URL 包含该关键字的内置浏览器 target，并附加到该页面。
+
+如果日志提示没有找到匹配 target，请确认 H5 页面已经在微信中打开，或改用更精确的 URL 关键字。自动附加失败时，可以继续参考 [EXTENSION.md](EXTENSION.md) 使用 Protocol Monitor 手动附加。
 
 ## 截图
 

--- a/src/cdp-router.selftest.ts
+++ b/src/cdp-router.selftest.ts
@@ -1,0 +1,245 @@
+import { CdpRouter } from "./cdp-router";
+
+type CapturedLog = { level: string; args: any[] };
+
+const createLogger = () => {
+    const logs: CapturedLog[] = [];
+    return {
+        logs,
+        logger: {
+            info: (...args: any[]) => logs.push({ level: "info", args }),
+            error: (...args: any[]) => logs.push({ level: "error", args }),
+            main_debug: (...args: any[]) => logs.push({ level: "debug", args }),
+        },
+    };
+};
+
+const collectRouterOutput = (router: CdpRouter) => {
+    const wechat: string[] = [];
+    const devtools: string[] = [];
+    router.on("wechat", (message) => wechat.push(message));
+    router.on("devtools", (message) => devtools.push(message));
+    return { wechat, devtools };
+};
+
+const parse = (message: string) => JSON.parse(message);
+
+const parsedMessages = (messages: string[]) => messages.map(parse);
+
+const findMessage = (messages: string[], predicate: (message: any) => boolean) =>
+    parsedMessages(messages).find(predicate);
+
+const messagesByMethod = (messages: string[], method: string) =>
+    parsedMessages(messages).filter((message) => message.method === method);
+
+const assert = (condition: unknown, message: string) => {
+    if (!condition) {
+        throw new Error(message);
+    }
+};
+
+const assertDeepEqual = (actual: unknown, expected: unknown, message: string) => {
+    const actualJson = JSON.stringify(actual);
+    const expectedJson = JSON.stringify(expected);
+    if (actualJson !== expectedJson) {
+        throw new Error(`${message}: expected ${expectedJson}, got ${actualJson}`);
+    }
+};
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitFor = async (condition: () => boolean, message: string, timeoutMs = 100) => {
+    const startedAt = Date.now();
+    while (!condition()) {
+        if (Date.now() - startedAt > timeoutMs) {
+            throw new Error(message);
+        }
+        await delay(1);
+    }
+};
+
+const testTransparentMode = () => {
+    const { logger } = createLogger();
+    const router = new CdpRouter({ h5Url: null }, logger);
+    const output = collectRouterOutput(router);
+
+    try {
+        const devtoolsMessage = JSON.stringify({ id: 1, method: "Runtime.enable" });
+        const wechatMessage = JSON.stringify({ id: 1, result: {} });
+        router.handleDevtoolsMessage(devtoolsMessage);
+        router.handleWechatMessage(wechatMessage);
+
+        assert(output.wechat.length === 1, "transparent mode forwards DevTools to WeChat");
+        assert(output.devtools.length === 1, "transparent mode forwards WeChat to DevTools");
+        assert(output.wechat[0] === devtoolsMessage, "transparent mode preserves DevTools message unchanged");
+        assert(output.devtools[0] === wechatMessage, "transparent mode preserves WeChat message unchanged");
+    } finally {
+        router.dispose();
+    }
+};
+
+const testH5DiscoveryAttachAndRouting = async () => {
+    const { logger } = createLogger();
+    const router = new CdpRouter(
+        { h5Url: "mp.weixin.qq.com", discoveryIntervalMs: 100, discoveryTimeoutMs: 1000 },
+        logger,
+    );
+    const output = collectRouterOutput(router);
+
+    try {
+        router.start();
+        router.handleDevtoolsMessage(JSON.stringify({ id: 7, method: "Runtime.enable" }));
+
+        await waitFor(
+            () => findMessage(output.wechat, (message) => message.method === "Target.getTargets") !== undefined,
+            "router sends Target.getTargets on start",
+        );
+        const getTargets = findMessage(output.wechat, (message) => message.method === "Target.getTargets");
+        assert(getTargets !== undefined, "first internal request is Target.getTargets");
+
+        router.handleWechatMessage(
+            JSON.stringify({
+                id: getTargets.id,
+                result: {
+                    targetInfos: [
+                        { targetId: "miniapp", type: "page", title: "AppIndex", url: "appservice://index" },
+                        { targetId: "h5", type: "page", title: "Official Account", url: "https://mp.weixin.qq.com/s/demo" },
+                    ],
+                },
+            }),
+        );
+
+        await waitFor(
+            () => findMessage(output.wechat, (message) => message.method === "Target.attachToTarget") !== undefined,
+            "router sends attach request after target match",
+        );
+        const attach = findMessage(output.wechat, (message) => message.method === "Target.attachToTarget");
+        assert(attach !== undefined, "second internal request is attach");
+        assert(attach.params.targetId === "h5", "attach uses matched target id");
+        assert(attach.params.flatten === true, "attach uses flattened sessions");
+        assert(
+            findMessage(output.wechat, (message) => message.id === 7 && message.method === "Runtime.enable") === undefined,
+            "queued Runtime.enable is not forwarded before attach succeeds",
+        );
+
+        router.handleWechatMessage(
+            JSON.stringify({
+                id: attach.id,
+                result: { sessionId: "session-h5" },
+            }),
+        );
+
+        await waitFor(
+            () => findMessage(output.wechat, (message) => message.id === 7 && message.sessionId === "session-h5") !== undefined,
+            "router flushes queued DevTools request after attach",
+        );
+        const flushed = findMessage(output.wechat, (message) => message.id === 7 && message.sessionId === "session-h5");
+        assert(flushed !== undefined, "flushed request is emitted");
+        assert(flushed.method === "Runtime.enable", "flushed request preserves method");
+
+        const resultPayload = { result: { type: "number", value: 42, description: "42" } };
+        router.handleWechatMessage(
+            JSON.stringify({
+                id: 7,
+                sessionId: "session-h5",
+                result: resultPayload,
+            }),
+        );
+
+        assert(output.devtools.length === 1, "router forwards active session response to DevTools");
+        const response = parse(output.devtools[0]);
+        assertDeepEqual(
+            response,
+            { id: 7, result: resultPayload },
+            "response preserves full payload and removes session id",
+        );
+
+        const topLevelWechatCountBefore = output.wechat.length;
+        router.handleDevtoolsMessage(JSON.stringify({ id: 8, method: "Browser.getVersion" }));
+        assert(
+            output.wechat.length === topLevelWechatCountBefore + 1,
+            "Browser.getVersion forwards to WeChat after attach",
+        );
+        const browserGetVersion = parse(output.wechat[output.wechat.length - 1]);
+        assert(browserGetVersion.id === 8, "Browser.getVersion preserves request id");
+        assert(browserGetVersion.method === "Browser.getVersion", "Browser.getVersion preserves method");
+        assert(browserGetVersion.sessionId === undefined, "Browser.getVersion stays top-level (no sessionId)");
+    } finally {
+        router.dispose();
+    }
+};
+
+const testDiscoveryTimeoutFailsQueuedAndLaterRequests = async () => {
+    const { logger } = createLogger();
+    const router = new CdpRouter(
+        { h5Url: "missing.example", discoveryIntervalMs: 20, discoveryTimeoutMs: 80 },
+        logger,
+    );
+    const output = collectRouterOutput(router);
+
+    try {
+        router.start();
+        router.handleDevtoolsMessage(JSON.stringify({ id: 11, method: "Runtime.enable" }));
+
+        await waitFor(() => messagesByMethod(output.wechat, "Target.getTargets").length >= 1, "router sends getTargets before timeout");
+        const firstGetTargets = messagesByMethod(output.wechat, "Target.getTargets")[0];
+        router.handleWechatMessage(
+            JSON.stringify({
+                id: firstGetTargets.id,
+                result: { targetInfos: [] },
+            }),
+        );
+
+        await waitFor(
+            () => messagesByMethod(output.wechat, "Target.getTargets").length >= 2,
+            "router retries Target.getTargets after no matching target",
+            150,
+        );
+        assert(
+            messagesByMethod(output.wechat, "Target.getTargets").length >= 2,
+            "timeout path proves at least one discovery retry",
+        );
+
+        await waitFor(() => output.devtools.length === 1, "timeout replies to queued DevTools request", 200);
+        const queuedError = parse(output.devtools[0]);
+        assert(queuedError.id === 11, "timeout error preserves queued request id");
+        assert(queuedError.error.code === -32000, "timeout error uses JSON-RPC -32000");
+        assert(
+            queuedError.error.message.includes("H5 target was not attached"),
+            "timeout error explains attach failure",
+        );
+
+        const wechatCountAfterFailure = output.wechat.length;
+        router.handleDevtoolsMessage(JSON.stringify({ id: 12, method: "Runtime.evaluate", params: { expression: "1" } }));
+
+        assert(output.devtools.length === 2, "later DevTools request fails immediately after terminal failure");
+        const laterError = parse(output.devtools[1]);
+        assert(laterError.id === 12, "later error preserves request id");
+        assert(laterError.error.code === -32000, "later error uses JSON-RPC -32000");
+        assert(output.wechat.length === wechatCountAfterFailure, "later failed request is not queued or forwarded");
+
+        router.handleDevtoolsMessage(JSON.stringify({ method: "Runtime.consoleAPICalled", params: { type: "log" } }));
+        assert(output.wechat.length === wechatCountAfterFailure, "later notification without id is dropped after terminal failure");
+
+        router.handleDevtoolsMessage(JSON.stringify({ id: 13, method: "Target.getTargets" }));
+        assert(output.wechat.length === wechatCountAfterFailure + 1, "later Target.getTargets is forwarded after terminal failure");
+        const manualGetTargets = parse(output.wechat[output.wechat.length - 1]);
+        assert(manualGetTargets.id === 13, "manual Target.getTargets preserves request id");
+        assert(manualGetTargets.method === "Target.getTargets", "manual Target.getTargets preserves method");
+        assert(manualGetTargets.sessionId === undefined, "manual Target.getTargets remains top-level");
+    } finally {
+        router.dispose();
+    }
+};
+
+const main = async () => {
+    testTransparentMode();
+    await testH5DiscoveryAttachAndRouting();
+    await testDiscoveryTimeoutFailsQueuedAndLaterRequests();
+    console.log("cdp-router selftest passed");
+};
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/src/cdp-router.ts
+++ b/src/cdp-router.ts
@@ -1,0 +1,542 @@
+import { EventEmitter } from "node:events";
+
+type JsonObject = Record<string, any>;
+
+type CdpTargetInfo = {
+    targetId: string;
+    type?: string;
+    title?: string;
+    url?: string;
+};
+
+type LoggerLike = {
+    info: (...args: any[]) => void;
+    error: (...args: any[]) => void;
+    main_debug: (...args: any[]) => void;
+};
+
+type CdpRouterOptions = {
+    h5Url: string | null;
+    discoveryIntervalMs?: number;
+    discoveryTimeoutMs?: number;
+};
+
+type PendingInternalRequest = {
+    kind: "getTargets" | "attach";
+    startedAt: number;
+    targetId?: string;
+    timer: ReturnType<typeof setTimeout>;
+};
+
+type QueuedDevtoolsMessage = {
+    id: number | string | null;
+    message: JsonObject;
+};
+
+const TOP_LEVEL_METHOD_PREFIXES = ["Target.", "Browser.", "SystemInfo."];
+
+class CdpRouter extends EventEmitter {
+    private readonly h5Url: string | null;
+    private readonly logger: LoggerLike;
+    private readonly discoveryIntervalMs: number;
+    private readonly discoveryTimeoutMs: number;
+    private readonly pendingInternalRequests = new Map<number, PendingInternalRequest>();
+    private readonly queuedDevtoolsMessages: QueuedDevtoolsMessage[] = [];
+    private readonly topLevelDevtoolsRequestIds = new Set<number | string>();
+    private internalRequestId = 900000000;
+    private activeSessionId: string | null = null;
+    private activeTargetId: string | null = null;
+    private discoveryStartedAt = 0;
+    private discoveryTimer: ReturnType<typeof setTimeout> | null = null;
+    private hasLoggedDiscoveryStart = false;
+    private lastVisibleTargets: CdpTargetInfo[] = [];
+    private terminalAttachFailureMessage: string | null = null;
+    private disposed = false;
+
+    constructor(options: CdpRouterOptions, logger: LoggerLike) {
+        super();
+        this.h5Url = options.h5Url;
+        this.logger = logger;
+        this.discoveryIntervalMs = options.discoveryIntervalMs ?? 500;
+        this.discoveryTimeoutMs = options.discoveryTimeoutMs ?? 15000;
+    }
+
+    isH5Mode() {
+        return this.h5Url !== null;
+    }
+
+    start() {
+        if (this.disposed) {
+            return;
+        }
+
+        if (!this.isH5Mode()) {
+            return;
+        }
+
+        this.terminalAttachFailureMessage = null;
+        this.discoveryStartedAt = Date.now();
+        this.scheduleDiscovery(0);
+    }
+
+    dispose() {
+        this.disposed = true;
+        if (this.discoveryTimer !== null) {
+            clearTimeout(this.discoveryTimer);
+            this.discoveryTimer = null;
+        }
+        this.clearPendingInternalRequests();
+    }
+
+    handleDevtoolsMessage(rawMessage: string) {
+        if (this.disposed) {
+            return;
+        }
+
+        if (!this.isH5Mode()) {
+            this.emit("wechat", rawMessage);
+            return;
+        }
+
+        const message = this.parseJson(rawMessage, "devtools");
+        if (message === null) {
+            return;
+        }
+
+        if (this.activeSessionId === null) {
+            if (this.terminalAttachFailureMessage !== null) {
+                if (this.shouldStayTopLevel(message)) {
+                    this.forwardDevtoolsMessage(message);
+                    return;
+                }
+
+                this.failDevtoolsMessage(message, this.terminalAttachFailureMessage);
+                return;
+            }
+
+            this.queueDevtoolsMessage(message);
+            return;
+        }
+
+        this.forwardDevtoolsMessage(message);
+    }
+
+    handleWechatMessage(rawMessage: string) {
+        if (this.disposed) {
+            return;
+        }
+
+        if (!this.isH5Mode()) {
+            this.emit("devtools", rawMessage);
+            return;
+        }
+
+        const message = this.parseJson(rawMessage, "wechat");
+        if (message === null) {
+            return;
+        }
+
+        if (message.sessionId !== undefined) {
+            if (message.sessionId === this.activeSessionId) {
+                const { sessionId, ...pageMessage } = message;
+                this.emitToDevtools(pageMessage);
+            }
+            return;
+        }
+
+        if (typeof message.id === "number" && this.pendingInternalRequests.has(message.id)) {
+            this.handleInternalResponse(message.id, message);
+            return;
+        }
+
+        if (message.id !== undefined && this.topLevelDevtoolsRequestIds.has(message.id)) {
+            this.topLevelDevtoolsRequestIds.delete(message.id);
+            this.emitToDevtools(message);
+            return;
+        }
+
+        if (typeof message.method === "string" && message.method.startsWith("Target.")) {
+            this.handleTargetLifecycleEvent(message);
+            this.logger.main_debug("[h5] top-level target event", message);
+            this.emitToDevtools(message);
+        }
+    }
+
+    private emitToWechat(message: JsonObject) {
+        if (this.disposed) {
+            return;
+        }
+
+        this.emit("wechat", JSON.stringify(message));
+    }
+
+    private emitToDevtools(message: JsonObject) {
+        if (this.disposed) {
+            return;
+        }
+
+        this.emit("devtools", JSON.stringify(message));
+    }
+
+    private nextInternalId() {
+        this.internalRequestId += 1;
+        return this.internalRequestId;
+    }
+
+    private sendInternalRequest(kind: PendingInternalRequest["kind"], method: string, params?: JsonObject) {
+        if (this.disposed) {
+            return;
+        }
+
+        const id = this.nextInternalId();
+        this.pendingInternalRequests.set(id, {
+            kind,
+            startedAt: Date.now(),
+            targetId: typeof params?.targetId === "string" ? params.targetId : undefined,
+            timer: setTimeout(() => {
+                if (this.disposed) {
+                    return;
+                }
+
+                this.handleInternalRequestTimeout(id);
+            }, this.getInternalRequestTimeoutMs()),
+        });
+        this.emitToWechat({
+            id,
+            method,
+            ...(params === undefined ? {} : { params }),
+        });
+        return id;
+    }
+
+    private scheduleDiscovery(delayMs: number) {
+        if (this.disposed || !this.isH5Mode() || this.activeSessionId !== null) {
+            return;
+        }
+
+        if (this.hasDiscoveryTimedOut()) {
+            this.logger.error(
+                `[h5] target not found for URL keyword: ${this.h5Url}`,
+            );
+            this.logVisibleTargets();
+            this.failTerminalAttach("H5 target was not attached: matching URL was not found");
+            return;
+        }
+
+        if (this.discoveryTimer !== null) {
+            clearTimeout(this.discoveryTimer);
+        }
+
+        this.discoveryTimer = setTimeout(() => {
+            if (this.disposed) {
+                return;
+            }
+
+            this.discoveryTimer = null;
+            this.discoverTargets();
+        }, delayMs);
+    }
+
+    private discoverTargets() {
+        if (this.disposed || !this.isH5Mode() || this.activeSessionId !== null) {
+            return;
+        }
+
+        if (this.hasDiscoveryTimedOut()) {
+            this.logger.error(
+                `[h5] target not found for URL keyword: ${this.h5Url}`,
+            );
+            this.logVisibleTargets();
+            this.failTerminalAttach("H5 target was not attached: matching URL was not found");
+            return;
+        }
+
+        if (!this.hasLoggedDiscoveryStart) {
+            this.logger.info(`[h5] searching target by URL keyword: ${this.h5Url}`);
+            this.hasLoggedDiscoveryStart = true;
+        }
+
+        this.sendInternalRequest("getTargets", "Target.getTargets");
+    }
+
+    private forwardDevtoolsMessage(message: JsonObject) {
+        if (this.shouldStayTopLevel(message)) {
+            if (message.id !== undefined) {
+                this.topLevelDevtoolsRequestIds.add(message.id);
+            }
+            this.emitToWechat(message);
+            return;
+        }
+
+        this.emitToWechat({
+            ...message,
+            sessionId: this.activeSessionId,
+        });
+    }
+
+    private shouldStayTopLevel(message: JsonObject) {
+        return (
+            typeof message.method === "string" &&
+            TOP_LEVEL_METHOD_PREFIXES.some((prefix) => message.method.startsWith(prefix))
+        );
+    }
+
+    private queueDevtoolsMessage(message: JsonObject) {
+        this.queuedDevtoolsMessages.push({
+            id: message.id ?? null,
+            message,
+        });
+    }
+
+    private handleInternalResponse(id: number, message: JsonObject) {
+        const pendingRequest = this.pendingInternalRequests.get(id);
+        this.pendingInternalRequests.delete(id);
+        if (pendingRequest === undefined) {
+            return;
+        }
+        clearTimeout(pendingRequest.timer);
+
+        if (message.error !== undefined) {
+            if (pendingRequest.kind === "attach") {
+                this.logger.error(`[h5] attach failed for target ${pendingRequest.targetId ?? "unknown"}:`, message.error);
+            } else {
+                this.logger.error(`[h5] ${pendingRequest.kind} failed:`, message.error);
+            }
+            if (pendingRequest.kind === "getTargets") {
+                this.scheduleDiscovery(this.discoveryIntervalMs);
+            } else {
+                this.handleAttachFailure("H5 target was not attached: attach failed");
+            }
+            return;
+        }
+
+        if (pendingRequest.kind === "getTargets") {
+            this.handleGetTargetsResult(message);
+            return;
+        }
+
+        if (pendingRequest.kind === "attach") {
+            this.handleAttachResult(message, pendingRequest);
+        }
+    }
+
+    private handleGetTargetsResult(message: JsonObject) {
+        const targetInfos = this.getTargetInfos(message);
+        this.lastVisibleTargets = targetInfos;
+        const matchedTarget = targetInfos.find((targetInfo) =>
+            typeof targetInfo.url === "string" && targetInfo.url.includes(this.h5Url as string),
+        );
+
+        if (matchedTarget === undefined) {
+            this.scheduleDiscovery(this.discoveryIntervalMs);
+            return;
+        }
+
+        this.logger.info(
+            `[h5] matched target: ${matchedTarget.targetId} ${matchedTarget.url ?? ""} ${matchedTarget.title ?? ""}`.trim(),
+        );
+        this.sendInternalRequest("attach", "Target.attachToTarget", {
+            targetId: matchedTarget.targetId,
+            flatten: true,
+        });
+    }
+
+    private handleAttachResult(message: JsonObject, pendingRequest: PendingInternalRequest) {
+        const sessionId = message.result?.sessionId;
+        if (typeof sessionId !== "string" || sessionId.length === 0) {
+            this.logger.error(`[h5] attach failed for target ${pendingRequest.targetId ?? "unknown"}: missing sessionId`, message);
+            this.handleAttachFailure("H5 target was not attached: attach response had no sessionId");
+            return;
+        }
+
+        this.activeSessionId = sessionId;
+        this.activeTargetId = pendingRequest.targetId ?? null;
+        this.logger.info(`[h5] attached target session: ${sessionId}`);
+        this.flushQueuedDevtoolsMessages();
+    }
+
+    private handleTargetLifecycleEvent(message: JsonObject) {
+        if (message.method === "Target.detachedFromTarget") {
+            const detachedSessionId = message.params?.sessionId;
+            if (detachedSessionId === this.activeSessionId) {
+                this.logger.info(`[h5] attached target detached: ${detachedSessionId}`);
+                this.restartDiscovery();
+            }
+            return;
+        }
+
+        if (message.method === "Target.targetDestroyed") {
+            const destroyedTargetId = message.params?.targetId;
+            if (destroyedTargetId === this.activeTargetId) {
+                this.logger.info(`[h5] attached target destroyed: ${destroyedTargetId}`);
+                this.restartDiscovery();
+            }
+        }
+    }
+
+    private restartDiscovery() {
+        if (this.disposed) {
+            return;
+        }
+
+        this.clearPendingInternalRequests();
+        this.activeSessionId = null;
+        this.activeTargetId = null;
+        this.terminalAttachFailureMessage = null;
+        this.discoveryStartedAt = Date.now();
+        this.hasLoggedDiscoveryStart = false;
+        this.scheduleDiscovery(0);
+    }
+
+    private handleInternalRequestTimeout(id: number) {
+        if (this.disposed) {
+            return;
+        }
+
+        const pendingRequest = this.pendingInternalRequests.get(id);
+        if (pendingRequest === undefined) {
+            return;
+        }
+
+        this.pendingInternalRequests.delete(id);
+        if (pendingRequest.kind === "attach") {
+            this.logger.error(
+                `[h5] attach timed out for target ${pendingRequest.targetId ?? "unknown"} after ${Date.now() - pendingRequest.startedAt}ms`,
+            );
+        } else {
+            this.logger.error(`[h5] ${pendingRequest.kind} timed out after ${Date.now() - pendingRequest.startedAt}ms`);
+        }
+
+        if (pendingRequest.kind === "getTargets") {
+            if (this.hasDiscoveryTimedOut()) {
+                this.logger.error(
+                    `[h5] target not found for URL keyword: ${this.h5Url}`,
+                );
+                this.logVisibleTargets();
+                this.failTerminalAttach("H5 target was not attached: matching URL was not found");
+                return;
+            }
+
+            this.scheduleDiscovery(this.discoveryIntervalMs);
+            return;
+        }
+
+        this.handleAttachFailure("H5 target was not attached: attach timed out");
+    }
+
+    private handleAttachFailure(message: string) {
+        this.failQueuedDevtoolsMessages(message);
+        this.activeSessionId = null;
+        this.activeTargetId = null;
+
+        if (this.hasDiscoveryTimedOut()) {
+            this.logger.error(
+                `[h5] target not found for URL keyword: ${this.h5Url}`,
+            );
+            this.logVisibleTargets();
+            this.terminalAttachFailureMessage = message;
+            return;
+        }
+
+        this.scheduleDiscovery(this.discoveryIntervalMs);
+    }
+
+    private getInternalRequestTimeoutMs() {
+        const remainingDiscoveryMs = this.discoveryTimeoutMs - (Date.now() - this.discoveryStartedAt);
+        return Math.max(1, Math.min(this.discoveryIntervalMs, remainingDiscoveryMs));
+    }
+
+    private hasDiscoveryTimedOut() {
+        return Date.now() - this.discoveryStartedAt > this.discoveryTimeoutMs;
+    }
+
+    private clearPendingInternalRequests() {
+        this.pendingInternalRequests.forEach((pendingRequest) => {
+            clearTimeout(pendingRequest.timer);
+        });
+        this.pendingInternalRequests.clear();
+    }
+
+    private parseJson(rawMessage: string, source: string) {
+        try {
+            const parsed = JSON.parse(rawMessage);
+            if (!this.isJsonObject(parsed)) {
+                this.logger.error(`[h5] invalid CDP JSON from ${source}: expected object`);
+                return null;
+            }
+
+            return parsed;
+        } catch (e) {
+            this.logger.error(`[h5] invalid CDP JSON from ${source}:`, e);
+            return null;
+        }
+    }
+
+    private isJsonObject(value: unknown): value is JsonObject {
+        return typeof value === "object" && value !== null && !Array.isArray(value);
+    }
+
+    private getTargetInfos(message: JsonObject): CdpTargetInfo[] {
+        const targetInfos = message.result?.targetInfos;
+        if (!Array.isArray(targetInfos)) {
+            return [];
+        }
+
+        return targetInfos.filter((targetInfo): targetInfo is CdpTargetInfo => {
+            return typeof targetInfo === "object" && targetInfo !== null && typeof targetInfo.targetId === "string";
+        });
+    }
+
+    private flushQueuedDevtoolsMessages() {
+        const queuedMessages = this.queuedDevtoolsMessages.splice(0);
+        queuedMessages.forEach((queuedMessage) => {
+            this.forwardDevtoolsMessage(queuedMessage.message);
+        });
+    }
+
+    private failQueuedDevtoolsMessages(message: string) {
+        const queuedMessages = this.queuedDevtoolsMessages.splice(0);
+        queuedMessages.forEach((queuedMessage) => {
+            if (queuedMessage.id === null) {
+                return;
+            }
+
+            this.failDevtoolsRequest(queuedMessage.id, message);
+        });
+    }
+
+    private failTerminalAttach(message: string) {
+        this.terminalAttachFailureMessage = message;
+        this.failQueuedDevtoolsMessages(message);
+    }
+
+    private failDevtoolsMessage(message: JsonObject, errorMessage: string) {
+        if (message.id === undefined || message.id === null) {
+            return;
+        }
+
+        this.failDevtoolsRequest(message.id, errorMessage);
+    }
+
+    private failDevtoolsRequest(id: number | string, message: string) {
+        this.emitToDevtools({
+            id,
+            error: {
+                code: -32000,
+                message,
+            },
+        });
+    }
+
+    private logVisibleTargets() {
+        const visibleTargets = this.lastVisibleTargets.map((targetInfo) => ({
+            targetId: targetInfo.targetId,
+            type: targetInfo.type ?? "",
+            title: targetInfo.title ?? "",
+            url: targetInfo.url ?? "",
+        }));
+        this.logger.error("[h5] visible targets:", visibleTargets);
+    }
+}
+
+export { CdpRouter, CdpRouterOptions };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ type CliOptions = {
     cdpPort: number;
     debugMain: boolean;
     debugFrida: boolean;
+    h5Url: string | null;
 };
 
 // default debugging port, do not change
@@ -19,6 +20,7 @@ const print_help = () => {
 Options:
   --debug-port <port>  Remote debug server port (default: ${DEBUG_PORT})
   --cdp-port <port>    CDP proxy server port (default: ${CDP_PORT})
+  --h5-url <keyword>   Auto attach to an embedded browser target whose URL contains keyword
   --debug-main         Output main process debug messages
   --debug-frida        Output Frida client messages
   -h, --help           Show this help message`);
@@ -41,11 +43,28 @@ const parse_port = (
     return port;
 };
 
+const parse_optional_non_empty_string = (
+    name: string,
+    value: string | undefined,
+) => {
+    if (value === undefined) {
+        return null;
+    }
+
+    const trimmedValue = value.trim();
+    if (trimmedValue.length === 0) {
+        throw new Error(`[main] invalid ${name}: value cannot be empty`);
+    }
+
+    return trimmedValue;
+};
+
 const parse_cli_options = (): CliOptions => {
     const { values } = parseArgs({
         options: {
             "debug-port": { type: "string" },
             "cdp-port": { type: "string" },
+            "h5-url": { type: "string" },
             "debug-main": { type: "boolean" },
             "debug-frida": { type: "boolean" },
             help: { type: "boolean", short: "h" },
@@ -61,6 +80,7 @@ const parse_cli_options = (): CliOptions => {
     return {
         debugPort: parse_port("--debug-port", values["debug-port"], DEBUG_PORT),
         cdpPort: parse_port("--cdp-port", values["cdp-port"], CDP_PORT),
+        h5Url: parse_optional_non_empty_string("--h5-url", values["h5-url"]),
         debugMain: values["debug-main"] ?? false,
         debugFrida: values["debug-frida"] ?? false,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import * as frida from "frida";
 import WebSocket, { WebSocketServer } from "ws";
 
 import { parse_cli_options, CliOptions } from "./cli";
+import { CdpRouter } from "./cdp-router";
 import { create_logger, Logger } from "./logger";
 
 const codex = require("./third-party/RemoteDebugCodex.js");
@@ -103,6 +104,7 @@ const debug_server = (options: CliOptions, logger: Logger) => {
 
 const proxy_server = (options: CliOptions, logger: Logger) => {
     const wss = new WebSocketServer({ port: options.cdpPort });
+    let activeH5Client: WebSocket | null = null;
     logger.info(
         `[server] proxy server running on ws://localhost:${options.cdpPort}`,
     );
@@ -110,29 +112,86 @@ const proxy_server = (options: CliOptions, logger: Logger) => {
         `[server] link: devtools://devtools/bundled/inspector.html?ws=127.0.0.1:${options.cdpPort}`,
     );
 
-    const onMessage = (message: string) => {
-        debugMessageEmitter.emit("proxymessage", message);
-    };
+    if (options.h5Url === null) {
+        const onMessage = (message: string) => {
+            debugMessageEmitter.emit("proxymessage", message.toString());
+        };
+
+        wss.on("connection", (ws: WebSocket) => {
+            logger.info("[cdp] CDP client connected");
+            ws.on("message", onMessage);
+            ws.on("error", (err) => {
+                logger.error("[cdp] CDP client err:", err);
+            });
+            ws.on("close", () => {
+                logger.info("[cdp] CDP client disconnected");
+            });
+        });
+
+        debugMessageEmitter.on("cdpmessage", (message: string) => {
+            wss &&
+                wss.clients.forEach((client) => {
+                    if (client.readyState === WebSocket.OPEN) {
+                        client.send(message);
+                    }
+                });
+        });
+
+        return;
+    }
+
+    logger.info(`[h5] auto attach enabled, URL keyword: ${options.h5Url}`);
 
     wss.on("connection", (ws: WebSocket) => {
+        if (activeH5Client !== null) {
+            logger.error(
+                "[cdp] rejecting CDP client: H5 mode allows only one active CDP client",
+            );
+            ws.close(1013, "H5 client active");
+            return;
+        }
+
+        activeH5Client = ws;
+
         logger.info("[cdp] CDP client connected");
-        ws.on("message", onMessage);
+        const router = new CdpRouter({ h5Url: options.h5Url }, logger);
+
+        const sendToWechat = (message: string) => {
+            debugMessageEmitter.emit("proxymessage", message);
+        };
+
+        const sendToDevtools = (message: string) => {
+            if (ws.readyState === WebSocket.OPEN) {
+                ws.send(message);
+            }
+        };
+
+        router.on("wechat", sendToWechat);
+        router.on("devtools", sendToDevtools);
+
+        const onCdpMessage = (message: string) => {
+            router.handleWechatMessage(message);
+        };
+
+        debugMessageEmitter.on("cdpmessage", onCdpMessage);
+        router.start();
+
+        ws.on("message", (message) => {
+            router.handleDevtoolsMessage(message.toString());
+        });
         ws.on("error", (err) => {
             logger.error("[cdp] CDP client err:", err);
         });
         ws.on("close", () => {
             logger.info("[cdp] CDP client disconnected");
+            if (activeH5Client === ws) {
+                activeH5Client = null;
+            }
+            router.dispose();
+            router.off("wechat", sendToWechat);
+            router.off("devtools", sendToDevtools);
+            debugMessageEmitter.off("cdpmessage", onCdpMessage);
         });
-    });
-
-    debugMessageEmitter.on("cdpmessage", (message: string) => {
-        wss &&
-            wss.clients.forEach((client) => {
-                if (client.readyState === WebSocket.OPEN) {
-                    // send CDP message to devtools
-                    client.send(message);
-                }
-            });
     });
 };
 

--- a/src/proxy-regression.selftest.ts
+++ b/src/proxy-regression.selftest.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const source = readFileSync(path.join(__dirname, "index.ts"), "utf8");
+
+const assert = (condition: unknown, message: string) => {
+    if (!condition) {
+        throw new Error(message);
+    }
+};
+
+assert(
+    source.includes("if (options.h5Url === null)"),
+    "proxy_server must keep an explicit raw non-H5 branch",
+);
+
+assert(
+    source.includes("client.send(message);"),
+    "raw non-H5 branch must broadcast WeChat CDP payloads directly to DevTools clients",
+);
+
+assert(
+    source.includes('debugMessageEmitter.emit("proxymessage", message.toString())'),
+    "raw non-H5 branch must forward DevTools messages directly to the miniapp bridge",
+);
+
+console.log("proxy regression selftest passed");


### PR DESCRIPTION
## Summary

Add automatic H5 page debugging support for WeChat Official Account pages via CDP target auto-attach mechanism.

## Changes

### New
- **\src/cdp-router.ts\**: CdpRouter module that orchestrates target discovery (\Target.getTargets\), keyword-based URL matching, attach (\Target.attachToTarget\ with flatten:true), session-aware message routing, request queuing, timeout handling, terminal failure detection, and manual \Target.*\ RPC fallback
- **\src/cdp-router.selftest.ts\**: Self-test covering transparent mode passthrough, H5 discovery/attach/flush/browser-level top-level routing, and terminal timeout/failure/fallback
- **\src/proxy-regression.selftest.ts\**: Source-level regression guard ensuring transparent proxy mode remains intact

### Modified
- **\src/cli.ts\**: Added \--h5-url <keyword>\ optional CLI argument
- **\src/index.ts\**: Per-connection \CdpRouter\ in H5 mode; original broadcast-only path preserved as explicit branch when \--h5-url\ is absent; single active H5 client guard
- **\README.md\**, **\README.zh.md\**: Added H5 debugging workflow to features list and usage guide
- **\EXTENSION.md\**: Documented H5 target automatic attach capabilities and fallback instructions

## H5 Debugging Workflow

1. Start WMPF and launch the target Official Account page inside WeChat
2. Run \
ode src/index.js --h5-url mp.weixin.qq.com\ (or use any URL keyword)
3. Open \chrome://inspect\ and connect to the debugger proxy
4. The proxy automatically discovers the H5 target, attaches to it, and routes all CDP commands to the page

Browser-level CDP methods (\Target.*\, \Browser.*\, \SystemInfo.*\) bypass session routing and go directly to the underlying endpoint, ensuring DevTools initialization works correctly.

## Testing

- \
px ts-node src/cdp-router.selftest.ts\ — passes
- \
px ts-node src/proxy-regression.selftest.ts\ — passes
- \
px tsc --noEmit\ — clean