### PR TITLE
Add WMPF 20089 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This debugger (tweak) exploits Remote Debug feature provided by wechatdevtools a
 
 Version histories:
 
-* 20079 (latest, credit @LiuYJia, @82539474)
+* 20089 (latest, credit @lovejiuwu)
+* 20079 (credit @LiuYJia, @82539474)
 * 20005 (credit @LiuYJia)
 * 20001 (credit @B1397KB)
 * 19977 (credit @B1397KB, @yunm90872-ui, @chengzongcai)

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,7 +9,8 @@
 
 支持的 WMPF 版本：
 
-* 20079 (最新, credit @LiuYJia, @82539474)
+* 20089 (最新, credit @lovejiuwu)
+* 20079 (credit @LiuYJia, @82539474)
 * 20005 (credit @LiuYJia)
 * 20001 (credit @B1397KB)
 * 19977 (credit @B1397KB, @yunm90872-ui, @chengzongcai)

--- a/frida/config/addresses.20089.json
+++ b/frida/config/addresses.20089.json
@@ -1,0 +1,6 @@
+{
+    "Version": 20089,
+    "LoadStartHookOffset": "0x25E0170",
+    "CDPFilterHookOffset": "0x30CF8F0",
+    "SceneOffsets": [64, 1480, 8, 1416, 16, 456]
+}


### PR DESCRIPTION
This PR adds support for WMPF version 20089.

Changes:
- add `frida/config/addresses.20089.json`
- update `README.md`
- update `README.zh.md`

Config used:
```json
{
    "Version": 20089,
    "LoadStartHookOffset": "0x25E0170",
    "CDPFilterHookOffset": "0x30CF8F0",
    "SceneOffsets": [64, 1480, 8, 1416, 16, 456]
}
```

Tested locally on WMPF 20089.