### PR TITLE
feat(frida/config): add 25364 version addresses config file

### DIFF
--- a/frida/config/addresses.25364.json
+++ b/frida/config/addresses.25364.json
@@ -1,0 +1,6 @@
+{
+    "Version": 25364,
+    "LoadStartHookOffset": "0x2a85700",
+    "CDPFilterHookOffset": "0x391c200",
+    "SceneOffsets": [64, 1512, 8, 1448, 16, 456]
+}


### PR DESCRIPTION
新增对应Frida版本25364的内存偏移地址配置文件，包含加载起始钩子、CDP过滤钩子偏移量以及场景偏移量配置