### PR TITLE
[config] support WMPF 25510 (Windows x86_64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This debugger (tweak) exploits Remote Debug feature provided by wechatdevtools a
 
 **Version histories:**
 
-* 25459 (latest, credit @1147529365)
+* 25510 (latest, credit @potacotion)
+* 25459 (credit @1147529365)
 * 25364 (credit @lyratu)
 * 25297 (credit @Yinuo0602, @82539474)
 * 25268 (credit @RuntimeBroker)

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,7 +11,8 @@
 
 **支持的 WMPF 版本：**
 
-* 25459 (最新, credit @1147529365)
+* 25510 (最新, credit @potacotion)
+* 25459 (credit @1147529365)
 * 25364 (credit @lyratu)
 * 25297 (credit @Yinuo0602, @82539474)
 * 25268 (credit @RuntimeBroker)

--- a/frida/config/win32/addresses.25510.json
+++ b/frida/config/win32/addresses.25510.json
@@ -1,0 +1,6 @@
+{
+    "Version": 25510,
+    "LoadStartHookOffset": "0x2ce4640",
+    "CDPFilterHookOffset": "0x3974ff0",
+    "SceneOffsets": [64, 1536, 8, 1472, 16, 456]
+}


### PR DESCRIPTION
## New WMPF version support: 25510 (Windows x86_64)

Adds `frida/config/win32/addresses.25510.json`:

```json
{
    "Version": 25510,
    "LoadStartHookOffset": "0x2ce4640",
    "CDPFilterHookOffset": "0x3974ff0",
    "SceneOffsets": [64, 1536, 8, 1472, 16, 456]
}
```

## How offsets were located

Static analysis of `flue.dll` (236 MB) via byte-level scanning + capstone disassembly (anchors followed per ADAPTATION.md):

- **LoadStartHookOffset** `0x2ce4640`: function `AppletIndexContainer::OnLoadStart(bool, const std::string &)` — references the `..\..\flue\browser\applet\applet_index_container.cc` literal (log line 998), takes the debug flag in `edx`, and walks `*(*(this+0x40) + 0x600)` into the scene check
- **CDPFilterHookOffset** `0x3974ff0`: first callee of the `SendToClientFilter` string xref function; its call site is immediately followed by `cmp dword ptr [rdi+8], 6` (matches the `retval+8 == 6` patch semantics)
- **SceneOffsets**: the scene-check function (found via the unique `cmp dword ptr [x+0x1C8], 0x44D` encoding — the constant 1101 appears exactly once in the whole binary) walks `+8 → +0x5C0 → +0x10 → +0x1C8`, i.e. `[64, 1536, 8, 1472, 16, 456]`, unchanged from 25459

## Verification

Verified live on WeChat 4.x with WMPF 25510:

```
[frida] script loaded, WMPF version: 25510, pid: 33204
[frida client] [inteceptor] AppletIndexContainer::OnLoadStart onEnter, indexContainer.this: 0x416c0dad6780
[frida client] [hook] scene: 1256
[frida client] [hook] hook scene condition -> 1101
[miniapp] miniapp client connected
[cdp] CDP client connected
[frida client] [patch] CDP filter on enter, original value of input: 0x416c04cc8338
[frida client] [patch] CDP filter on leave, patch input, now value: 0x416c067e4e60; *(input + 8) = 6
```

End-to-end: `Runtime.evaluate("1+1")` through the CDP proxy (ws://127.0.0.1:62000) returned `{"type":"number","value":2}` executed inside the mini program.

Also updates the Support Status lists in both READMEs.
