### PR TITLE
[scene] support launch scenes 1011, 1012, and 1037

### DIFF
--- a/frida/hook.js
+++ b/frida/hook.js
@@ -60,8 +60,11 @@ const hookOnLoadScene = (a1, sceneOffsets) => {
     // 1000: from issue #83 <-- will crash the process
     // 1007: from issue #80
     // 1008: from issue #53
+    // 1011: scan QR code
+    // 1012: recognize QR code from long-pressed image (issue #128)
     // 1027: from issue #78
     // 1035: from issue #78
+    // 1037: opened from another mini program
     // 1053: from issue #25
     // 1074: from issue #32
     // 1145: from search
@@ -71,8 +74,8 @@ const hookOnLoadScene = (a1, sceneOffsets) => {
     // 1302: from services
     // 1308: minigame?
     const sceneNumberArray = [
-        1005, 1007, 1008, 1027, 1035, 1053, 1074, 1145, 1178, 1256, 1260, 1302,
-        1308,
+        1005, 1007, 1008, 1011, 1012, 1027, 1035, 1037, 1053, 1074, 1145, 1178,
+        1256, 1260, 1302, 1308,
     ];
     if (!sceneNumberArray.includes(miniappScenePtr.readInt())) {
         return;


### PR DESCRIPTION
## Summary

- enable remote debugging for QR-code scan launches (`1011`)
- enable remote debugging for long-press QR-code recognition (`1012`)
- enable remote debugging when opened from another mini program (`1037`)
- document the three scene values next to the existing whitelist

Without these values in `sceneNumberArray`, these launch scenes are not rewritten to remote-debug scene `1101`, so DevTools can remain blank for these launch paths. Issue #128 includes a runtime report for scene `1012`.

The scene values follow the official WeChat Mini Program scene list:
https://developers.weixin.qq.com/miniprogram/dev/reference/scene-list.html

## Verification

- `node --check frida/hook.js`
- `npx tsc --noEmit`
- downstream runtime verification on Windows / WMPF 25297
