### PR TITLE
[config] support WMPF 25558 (Windows x86_64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This debugger (tweak) exploits Remote Debug feature provided by wechatdevtools a
 
 **Version histories:**
 
-* 25510 (latest, credit @potacotion)
+* 25558 (latest, credit @potacotion)
+* 25510 (credit @potacotion)
 * 25459 (credit @1147529365)
 * 25364 (credit @lyratu)
 * 25297 (credit @Yinuo0602, @82539474)

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,7 +11,8 @@
 
 **支持的 WMPF 版本：**
 
-* 25510 (最新, credit @potacotion)
+* 25558 (最新, credit @potacotion)
+* 25510 (credit @potacotion)
 * 25459 (credit @1147529365)
 * 25364 (credit @lyratu)
 * 25297 (credit @Yinuo0602, @82539474)

--- a/frida/config/win32/addresses.25558.json
+++ b/frida/config/win32/addresses.25558.json
@@ -1,0 +1,13 @@
+{
+    "Version": 25558,
+    "LoadStartHookOffset": "0x2ce7c50",
+    "CDPFilterHookOffset": "0x3978930",
+    "SceneOffsets": [
+        64,
+        1536,
+        8,
+        1472,
+        16,
+        456
+    ]
+}


### PR DESCRIPTION
## New WMPF version support: 25558 (Windows x86_64)

Adds `frida/config/win32/addresses.25558.json`:

```json
{
    "Version": 25558,
    "LoadStartHookOffset": "0x2ce7c50",
    "CDPFilterHookOffset": "0x3978930",
    "SceneOffsets": [64, 1536, 8, 1472, 16, 456]
}
```

Compared to 25510 (PR #265): `LoadStartHookOffset +0x3610`, `CDPFilterHookOffset +0x3940`, `SceneOffsets` unchanged (structures identical).

## How offsets were located

Same methodology as #265, automated into a static pipeline (byte-level scan + capstone, no IDA required):

- **Scene check function** `0x363a690`: located via the unique `cmp dword ptr [x+0x1C8], 0x44D` encoding (constant 1101 appears exactly once in the whole binary), contains the `ws:__localhost:9421` construction; chain tail `+8 → +0x5C0 → +0x10 → +0x1C8`
- **LoadStartHookOffset** `0x2ce7c50`: the only direct caller of the scene check function (`call @ 0x2ce7e80`); register backtracking at the call site yields `*(*(this+0x40) + 0x600)`; corroborated by the `..\..\flue\browser\applet\applet_index_container.cc` literal reference and the debug flag (`edx`) read at entry
- **CDPFilterHookOffset** `0x3978930`: first callee of the `SendToClientFilter` string xref function; call site followed by `cmp dword ptr [rdi+8], 6` (matches the `retval+8 == 6` patch semantics)

## Verification

Verified live on WeChat 4.x with WMPF 25558:

```
[frida] script loaded, WMPF version: 25558, pid: 39496
[frida client] [inteceptor] AppletIndexContainer::OnLoadStart onEnter, indexContainer.this: 0x3f8c09149e80
[frida client] [hook] scene: 1101
[frida client] [hook] hook scene condition -> 1101
[miniapp] miniapp client connected
[cdp] CDP client connected
[frida client] [patch] CDP filter on enter, original value of input: 0x3f8c0d38e878
[frida client] [patch] CDP filter on leave, patch input, now value: 0x3f8c0c4040c0; *(input + 8) = 6
```

End-to-end: `Runtime.evaluate("1+1")` through the CDP proxy (ws://127.0.0.1:62000) returned `{"type":"number","value":2}` executed inside the mini program.

Also updates the Support Status lists in both READMEs.
